### PR TITLE
Create npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+node_modules

--- a/BadTVShader.js
+++ b/BadTVShader.js
@@ -35,8 +35,11 @@
  * THE SOFTWARE.
  * 
  */
+(function(root) {
 
-THREE.BadTVShader = {
+var THREE = root.THREE || require('three');
+
+var BadTVShader = THREE.BadTVShader = {
 	uniforms: {
 		"tDiffuse": 	{ type: "t", value: null },
 		"time": 		{ type: "f", value: 0.0 },
@@ -135,3 +138,12 @@ THREE.BadTVShader = {
 	].join("\n")
 
 };
+
+if (typeof exports !== 'undefined') {
+	if (typeof module !== 'undefined' && module.exports) {
+		exports = module.exports = BadTVShader;
+	}
+	exports.BadTVShader = BadTVShader;
+}
+
+}(this));

--- a/example/js/BadTVShader.js
+++ b/example/js/BadTVShader.js
@@ -35,8 +35,11 @@
  * THE SOFTWARE.
  * 
  */
+(function(root) {
 
-THREE.BadTVShader = {
+var THREE = root.THREE || require('three');
+
+var BadTVShader = THREE.BadTVShader = {
 	uniforms: {
 		"tDiffuse": 	{ type: "t", value: null },
 		"time": 		{ type: "f", value: 0.0 },
@@ -135,3 +138,12 @@ THREE.BadTVShader = {
 	].join("\n")
 
 };
+
+if (typeof exports !== 'undefined') {
+	if (typeof module !== 'undefined' && module.exports) {
+		exports = module.exports = BadTVShader;
+	}
+	exports.BadTVShader = BadTVShader;
+}
+
+}(this));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bad-tv-shader",
+  "version": "0.0.0",
+  "description": "Simulates a bad TV via horizontal distortion and vertical roll.",
+  "main": "BadTVShader.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felixturner/bad-tv-shader.git"
+  },
+  "keywords": [
+    "three.js",
+    "three",
+    "shader",
+    "webgl",
+    "tv"
+  ],
+  "author": "felixturner",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/felixturner/bad-tv-shader/issues"
+  },
+  "homepage": "https://github.com/felixturner/bad-tv-shader#readme",
+  "dependencies": {
+    "three": "^0.82.1"
+  }
+}


### PR DESCRIPTION
Creates an npm packages for this shader so that it can be consumed more easily. I've tried to preserve the existing functionality by using the global `THREE` if it is available and only exporting anything if `modules` or `exports` are defined. 


Thanks for the great shader. I'm having lots of fun using it in some VR/AR experiments 

